### PR TITLE
fix(GitService): Cannot push tags to remote #2 #breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ dotnet tool install --global Versioning.NET
 
 ## Changelog
 
+### v0.2.0
+
+Major Changes
+
+* Changed IGitService.GetBranchTipId to support remote target
+* Removed Revision support from IncrementVersionWithGitIntegrationCommand
+
+Minor Changes
+
+* Fixed an issue finding the branch tip ID in GetIncrementFromCommitHintsHandler
+* Fixed an issue pushing tags to remote from IncrementVersionWithGitIntegrationHandler
+
 ### v0.1.2
 
 Minor Changes

--- a/Versioning.NET.sln
+++ b/Versioning.NET.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Presentation.Console.Tests"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapping.Tests", "tst\Mapping.Tests\Mapping.Tests.csproj", "{7F253D77-1A08-4304-9EA4-495B5337B37E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration.Tests", "tst\Integration.Tests\Integration.Tests.csproj", "{05DC8AAA-0EF6-4DD3-89EA-626298518F3C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +94,10 @@ Global
 		{7F253D77-1A08-4304-9EA4-495B5337B37E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F253D77-1A08-4304-9EA4-495B5337B37E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F253D77-1A08-4304-9EA4-495B5337B37E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05DC8AAA-0EF6-4DD3-89EA-626298518F3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05DC8AAA-0EF6-4DD3-89EA-626298518F3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05DC8AAA-0EF6-4DD3-89EA-626298518F3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05DC8AAA-0EF6-4DD3-89EA-626298518F3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,6 +118,7 @@ Global
 		{275B5BC4-00B3-416C-92D3-647482DBBC2C} = {770AA7B9-8254-4020-B9AB-DCA2F2A248A3}
 		{E524B658-47EE-44CF-AF56-773C5827028A} = {770AA7B9-8254-4020-B9AB-DCA2F2A248A3}
 		{7F253D77-1A08-4304-9EA4-495B5337B37E} = {770AA7B9-8254-4020-B9AB-DCA2F2A248A3}
+		{05DC8AAA-0EF6-4DD3-89EA-626298518F3C} = {770AA7B9-8254-4020-B9AB-DCA2F2A248A3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {366D1276-B771-479D-890C-1C96A50C4BC7}

--- a/src/Application/GitVersioning/Commands/IncrementVersionWithGitIntegrationCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithGitIntegrationCommand.cs
@@ -14,11 +14,6 @@ namespace Application.GitVersioning.Commands
         public string GitDirectory { get; set; } = string.Empty;
 
         /// <summary>
-        /// Git revision used to filter git commits from log.
-        /// </summary>
-        public string? Revision { get; set; }
-
-        /// <summary>
         /// The author email to use when creating a commit.
         /// </summary>
         public string CommitAuthorEmail { get; set; } = string.Empty;

--- a/src/Application/GitVersioning/Handlers/GetIncrementFromCommitHintsHandler.cs
+++ b/src/Application/GitVersioning/Handlers/GetIncrementFromCommitHintsHandler.cs
@@ -43,7 +43,7 @@ namespace Application.GitVersioning.Handlers
             var tags = _gitService.GetTags(request.GitDirectory);
             var latestTag = _gitVersioningService.GetLatestVersionTag(tags);
             var untilHash = _gitService.GetTagId(request.GitDirectory, latestTag.Key);
-            var fromHash = _gitService.GetBranchTipId(request.GitDirectory, request.TipBranchName);
+            var fromHash = _gitService.GetBranchTipId(request.GitDirectory, request.RemoteTarget, request.TipBranchName);
             var filter = new GitCommitFilter
             {
                 FromHash = fromHash,

--- a/src/Application/GitVersioning/Handlers/IncrementVersionWithGitIntegrationHandler.cs
+++ b/src/Application/GitVersioning/Handlers/IncrementVersionWithGitIntegrationHandler.cs
@@ -41,7 +41,7 @@ namespace Application.GitVersioning.Handlers
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         public async Task<Unit> Handle(IncrementVersionWithGitIntegrationCommand request, CancellationToken cancellationToken)
         {
-            var query = new GetIncrementFromCommitHintsQuery { GitDirectory = request.GitDirectory, TipBranchName = request.BranchName };
+            var query = new GetIncrementFromCommitHintsQuery { GitDirectory = request.GitDirectory, RemoteTarget = request.RemoteTarget, TipBranchName = request.BranchName };
             VersionIncrement increment = await _mediator.Send(query, cancellationToken);
 
             if (increment == VersionIncrement.None || increment == VersionIncrement.Unknown)
@@ -68,7 +68,7 @@ namespace Application.GitVersioning.Handlers
 
             _gitService.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/heads/{request.BranchName}");
             _gitService.CreateTag(request.GitDirectory, tagValue, commitId);
-            _gitService.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/heads/{tagValue}");
+            _gitService.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/tags/{tagValue}");
 
             return Unit.Value;
         }

--- a/src/Application/GitVersioning/Queries/GetIncrementFromCommitHintsQuery.cs
+++ b/src/Application/GitVersioning/Queries/GetIncrementFromCommitHintsQuery.cs
@@ -14,6 +14,11 @@ namespace Application.GitVersioning.Queries
         public string GitDirectory { get; set; } = string.Empty;
 
         /// <summary>
+        /// The git remote target. Defaults to 'origin'.
+        /// </summary>
+        public string RemoteTarget { get; set; } = "origin";
+
+        /// <summary>
         /// The branch name to use as the TIP.
         /// </summary>
         public string TipBranchName { get; set; } = string.Empty;

--- a/src/Application/Interfaces/IGitService.cs
+++ b/src/Application/Interfaces/IGitService.cs
@@ -33,8 +33,9 @@ namespace Application.Interfaces
         /// Retrieve the hash identifier for the commit at the tip of the branch.
         /// </summary>
         /// <param name="gitDirectory">The directory containing the .git folder.</param>
+        /// <param name="remoteTarget">The git target location identifier. Typically this value is 'origin'.</param>
         /// <param name="branchName">The name of the branch.</param>
-        public string GetBranchTipId(string gitDirectory, string branchName);
+        public string GetBranchTipId(string gitDirectory, string remoteTarget, string branchName);
 
         /// <summary>
         /// Retrieve a collection of git tags.

--- a/src/Infrastructure/Services/LibGit2Service.cs
+++ b/src/Infrastructure/Services/LibGit2Service.cs
@@ -84,11 +84,12 @@ namespace Infrastructure.Services
         /// Retrieve the hash identifier for the commit at the tip of the branch.
         /// </summary>
         /// <param name="gitDirectory">The directory containing the .git folder.</param>
+        /// <param name="remoteTarget">The git target location identifier. Typically this value is 'origin'.</param>
         /// <param name="branchName">The name of the branch.</param>
-        public string GetBranchTipId(string gitDirectory, string branchName)
+        public string GetBranchTipId(string gitDirectory, string remoteTarget, string branchName)
         {
             using var repo = new Repository(gitDirectory);
-            return repo.Branches[branchName]?.Tip.Id.ToString() ?? string.Empty;
+            return repo.Branches[$"{remoteTarget}/{branchName}"]?.Tip.Id.ToString() ?? string.Empty;
         }
 
         /// <summary>
@@ -98,7 +99,6 @@ namespace Infrastructure.Services
         public IEnumerable<string> GetTags(string gitDirectory)
         {
             using var repo = new Repository(gitDirectory);
-
             return repo.Tags.Select(repoTag => repoTag.FriendlyName).ToList();
         }
 

--- a/src/Presentation.Console/Commands/IncrementVersionWithGit.cs
+++ b/src/Presentation.Console/Commands/IncrementVersionWithGit.cs
@@ -64,7 +64,6 @@ namespace Presentation.Console.Commands
             var command = new IncrementVersionWithGitIntegrationCommand
             {
                 GitDirectory = GitDirectory,
-                Revision = Revision,
                 CommitAuthorEmail = AuthorEmail,
                 RemoteTarget = RemoteTarget,
                 BranchName = BranchName

--- a/tst/Integration.Tests/Handlers/IncrementVersionWithGitIntegrationHandlerTests.cs
+++ b/tst/Integration.Tests/Handlers/IncrementVersionWithGitIntegrationHandlerTests.cs
@@ -1,0 +1,53 @@
+﻿using Application.GitVersioning.Commands;
+using Application.GitVersioning.Handlers;
+using Application.Interfaces;
+using Integration.Tests.Setup;
+using LibGit2Sharp;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Integration.Tests.Handlers
+{
+    public class IncrementVersionWithGitIntegrationHandlerTests : GitSetup, IClassFixture<Orchestrator>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public IncrementVersionWithGitIntegrationHandlerTests(Orchestrator orchestrator)
+        {
+            _serviceProvider = orchestrator.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void Handle_WorksAsExpected()
+        {
+            // Arrange
+            using var repo = new Repository(TestRepoDirectory);
+            repo.Network.Remotes.Update("origin", updater =>
+            {
+                var token = Environment.GetEnvironmentVariable("GitHubAccessToken");
+                var url = $"https://cbcrouse:{token}@github.com/cbcrouse/Versioning.NET.Tests.git";
+                updater.Url = url;
+                updater.PushUrl = url;
+            });
+            var mediator = _serviceProvider.GetRequiredService<IMediator>();
+            var gitService = _serviceProvider.GetRequiredService<IGitService>();
+            var versioningService = _serviceProvider.GetRequiredService<IAssemblyVersioningService>();
+            var sut = new IncrementVersionWithGitIntegrationHandler(mediator, gitService, versioningService);
+
+            var command = new IncrementVersionWithGitIntegrationCommand
+            {
+                GitDirectory = TestRepoDirectory,
+                BranchName = "main",
+                RemoteTarget = "origin",
+                CommitAuthorEmail = "support@versioning.net"
+            };
+
+            // Act
+            //_ = await sut.Handle(command, CancellationToken.None);
+
+            // Assert
+        }
+    }
+}

--- a/tst/Integration.Tests/Integration.Tests.csproj
+++ b/tst/Integration.Tests/Integration.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="DynamicDependentFile" />
+    <ProjectCapability Include="DynamicFileNesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Presentation.Console\Presentation.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tst/Integration.Tests/Services/GitIntegrationTests.AssemblyVersioningTests.cs
+++ b/tst/Integration.Tests/Services/GitIntegrationTests.AssemblyVersioningTests.cs
@@ -5,7 +5,7 @@ using Semver;
 using System;
 using Xunit;
 
-namespace Infrastructure.Tests.Services
+namespace Integration.Tests.Services
 {
     public partial class GitIntegrationTests
     {

--- a/tst/Integration.Tests/Services/GitIntegrationTests.LibGit2ServiceTests.cs
+++ b/tst/Integration.Tests/Services/GitIntegrationTests.LibGit2ServiceTests.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace Infrastructure.Tests.Services
+namespace Integration.Tests.Services
 {
     public partial class GitIntegrationTests
     {
@@ -93,10 +93,11 @@ namespace Infrastructure.Tests.Services
             // Arrange
             var sut = new LibGit2Service();
             var expectedHash = "7097663ae5037990a057417aa7b1a8f99730f1ad";
-            var branchName = "origin/branch-tip-control-state";
+            var remoteTarget = "origin";
+            var branchName = "branch-tip-control-state";
 
             // Act
-            var actualHash = sut.GetBranchTipId(TestRepoDirectory, branchName);
+            var actualHash = sut.GetBranchTipId(TestRepoDirectory, remoteTarget, branchName);
 
             // Assert
             Assert.Equal(expectedHash, actualHash);

--- a/tst/Integration.Tests/Services/GitIntegrationTests.cs
+++ b/tst/Integration.Tests/Services/GitIntegrationTests.cs
@@ -1,6 +1,6 @@
-﻿using Infrastructure.Tests.Setup;
+﻿using Integration.Tests.Setup;
 
-namespace Infrastructure.Tests.Services
+namespace Integration.Tests.Services
 {
     public partial class GitIntegrationTests : GitSetup
     {

--- a/tst/Integration.Tests/Setup/GitSetup.cs
+++ b/tst/Integration.Tests/Setup/GitSetup.cs
@@ -2,7 +2,7 @@
 using System;
 using System.IO;
 
-namespace Infrastructure.Tests.Setup
+namespace Integration.Tests.Setup
 {
     /// <summary>
     /// Helper class for tests to setup git directory

--- a/tst/Integration.Tests/Setup/Orchestrator.cs
+++ b/tst/Integration.Tests/Setup/Orchestrator.cs
@@ -1,18 +1,18 @@
-using AutoMapper;
-using Common.Configuration;
+﻿using Common.Configuration;
 using Infrastructure.Startup;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
 
-namespace Mapping.Tests
+namespace Integration.Tests.Setup
 {
-    public partial class MappingTests
+    public class Orchestrator
     {
-        public IMapper Sut { get; }
-
-        public MappingTests()
+        public IServiceProvider BuildServiceProvider()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddConsole());
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddPrioritizedSettings();
             var configuration = configurationBuilder.Build();
@@ -20,9 +20,7 @@ namespace Mapping.Tests
             orchestrator.InitializeConfiguration(configuration);
             orchestrator.InitializeServiceCollection(serviceCollection);
             orchestrator.Orchestrate();
-
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-            Sut = serviceProvider.GetRequiredService<IMapper>();
+            return serviceCollection.BuildServiceProvider();
         }
     }
 }


### PR DESCRIPTION
The previous commit to fix issue #2 was falsely successful.

* Fixed an issue finding the branch tip ID in GetIncrementFromCommitHintsHandler
* Fixed an issue pushing tags to remote from IncrementVersionWithGitIntegrationHandler
* Changed IGitService.GetBranchTipId to support remote target
* Removed Revision support from IncrementVersionWithGitIntegrationCommand