### PR TITLE
Add support for manual version increment with git

### DIFF
--- a/src/Application/GitVersioning/Commands/IncrementVersionWithGitCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithGitCommand.cs
@@ -1,0 +1,52 @@
+﻿using Domain.Enumerations;
+using MediatR;
+using System.IO;
+
+namespace Application.GitVersioning.Commands
+{
+    /// <summary>
+    /// The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration.
+    /// </summary>
+    public class IncrementVersionWithGitCommand : IRequest<Unit>
+    {
+        /// <summary>
+        /// Gets or sets the directory containing the .git folder.
+        /// </summary>
+        public string GitDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the directory to target for file versioning.
+        /// </summary>
+        public string TargetDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the search option to use with the <see cref="TargetDirectory"/>.
+        /// </summary>
+        public SearchOption SearchOption { get; set;} = SearchOption.AllDirectories;
+
+        /// <summary>
+        /// Gets or sets the author email to use when creating a commit.
+        /// </summary>
+        public string CommitAuthorEmail { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the git remote target. Defaults to 'origin'.
+        /// </summary>
+        public string RemoteTarget { get; set; } = "origin";
+
+        /// <summary>
+        /// Gets or sets the name of the branch to update.
+        /// </summary>
+        public string BranchName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets how to increment the version.
+        /// </summary>
+        public VersionIncrement VersionIncrement { get; set; } = VersionIncrement.None;
+
+        /// <summary>
+        /// Gets or sets whether beta mode should be exited.
+        /// </summary>
+        public bool ExitBeta { get; set; } = false;
+    }
+}

--- a/src/Application/GitVersioning/Commands/IncrementVersionWithGitHintsCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithGitHintsCommand.cs
@@ -1,13 +1,13 @@
-﻿#nullable enable
+﻿using Domain.Enumerations;
 using MediatR;
 using System.IO;
 
 namespace Application.GitVersioning.Commands
 {
     /// <summary>
-    /// The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration.
+    /// The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration based on git commit messages.
     /// </summary>
-    public class IncrementVersionWithGitIntegrationCommand : IRequest<Unit>
+    public class IncrementVersionWithGitHintsCommand : IRequest<Unit>
     {
         /// <summary>
         /// Gets or sets the directory containing the .git folder.

--- a/src/Application/GitVersioning/Handlers/IncrementVersionWithGitHandler.cs
+++ b/src/Application/GitVersioning/Handlers/IncrementVersionWithGitHandler.cs
@@ -1,0 +1,83 @@
+﻿using Application.AssemblyVersioning.Commands;
+using Application.GitVersioning.Commands;
+using Application.GitVersioning.Queries;
+using Application.Interfaces;
+using Domain.Entities;
+using Domain.Enumerations;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Semver;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Application.GitVersioning.Handlers
+{
+    /// <summary>
+    /// The <see cref="IRequestHandler{TRequest,TResponse}"/> responsible for incrementing the version with git integration.
+    /// </summary>
+    public class IncrementVersionWithGitHandler : IRequestHandler<IncrementVersionWithGitCommand, Unit>
+    {
+        private readonly IMediator _mediator;
+        private readonly IGitService _gitService;
+        private readonly IAssemblyVersioningService _assemblyVersioningService;
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        /// <param name="mediator">An abstraction for accessing application behaviors.</param>
+        /// <param name="gitService">An abstraction to facilitate testing without using the git integration.</param>
+        /// <param name="assemblyVersioningService">An abstraction for working with assembly versions.</param>
+        public IncrementVersionWithGitHandler(
+            IMediator mediator,
+            IGitService gitService,
+            IAssemblyVersioningService assemblyVersioningService)
+        {
+            _mediator = mediator;
+            _gitService = gitService;
+            _assemblyVersioningService = assemblyVersioningService;
+        }
+
+        /// <summary>Handles the request to increment the version with git integration.</summary>
+        /// <param name="request">The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        public async Task<Unit> Handle(IncrementVersionWithGitCommand request, CancellationToken cancellationToken)
+        {
+            if (request.VersionIncrement is VersionIncrement.None or VersionIncrement.Unknown)
+            {
+                return Unit.Value;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.TargetDirectory))
+            {
+                request.TargetDirectory = request.GitDirectory;
+            }
+
+            SemVersion originalAssemblyVersion = _assemblyVersioningService.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption);
+
+            var command = new IncrementAssemblyVersionCommand
+            {
+                Directory = request.TargetDirectory,
+                SearchOption = request.SearchOption,
+                VersionIncrement = request.VersionIncrement,
+                ExitBeta = request.ExitBeta
+            };
+            await _mediator.Send(command, cancellationToken);
+
+            SemVersion currentAssemblyVersion = _assemblyVersioningService.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption);
+
+            var commitMessage = $"ci(Versioning): Increment version {originalAssemblyVersion} -> {currentAssemblyVersion} [skip ci] [skip hint]";
+            _gitService.CommitChanges(request.GitDirectory, commitMessage, request.CommitAuthorEmail);
+
+            string commitId = _gitService.GetCommits(request.GitDirectory).First(x => x.Subject.Equals(commitMessage)).Id;
+            string tagValue = $"v{currentAssemblyVersion}";
+
+            _gitService.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/heads/{request.BranchName}");
+            _gitService.CreateTag(request.GitDirectory, tagValue, commitId);
+            _gitService.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/tags/{tagValue}");
+
+            return Unit.Value;
+        }
+    }
+}

--- a/src/Application/GitVersioning/Handlers/IncrementVersionWithGitHintsHandler.cs
+++ b/src/Application/GitVersioning/Handlers/IncrementVersionWithGitHintsHandler.cs
@@ -15,15 +15,15 @@ using System.Threading.Tasks;
 namespace Application.GitVersioning.Handlers
 {
     /// <summary>
-    /// The <see cref="IRequestHandler{TRequest,TResponse}"/> responsible for incrementing the version with git integration.
+    /// The <see cref="IRequestHandler{TRequest,TResponse}"/> responsible for incrementing the version with git integration based on git commit messages.
     /// </summary>
-    public class IncrementVersionWithGitIntegrationHandler : IRequestHandler<IncrementVersionWithGitIntegrationCommand, Unit>
+    public class IncrementVersionWithGitHintsHandler : IRequestHandler<IncrementVersionWithGitHintsCommand, Unit>
     {
         private readonly IMediator _mediator;
         private readonly IGitService _gitService;
         private readonly IGitVersioningService _gitVersioningService;
         private readonly IAssemblyVersioningService _assemblyVersioningService;
-        private readonly ILogger<IncrementVersionWithGitIntegrationHandler> _logger;
+        private readonly ILogger<IncrementVersionWithGitHintsHandler> _logger;
 
         /// <summary>
         /// Default Constructor
@@ -33,12 +33,12 @@ namespace Application.GitVersioning.Handlers
         /// <param name="gitVersioningService">An abstraction for retrieving version hint info from git commit messages.</param>
         /// <param name="assemblyVersioningService">An abstraction for working with assembly versions.</param>
         /// <param name="logger">A generic interface for logging.</param>
-        public IncrementVersionWithGitIntegrationHandler(
+        public IncrementVersionWithGitHintsHandler(
             IMediator mediator,
             IGitService gitService,
             IGitVersioningService gitVersioningService,
             IAssemblyVersioningService assemblyVersioningService,
-            ILogger<IncrementVersionWithGitIntegrationHandler> logger)
+            ILogger<IncrementVersionWithGitHintsHandler> logger)
         {
             _mediator = mediator;
             _gitService = gitService;
@@ -50,7 +50,7 @@ namespace Application.GitVersioning.Handlers
         /// <summary>Handles the request to increment the version with git integration.</summary>
         /// <param name="request">The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration.</param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-        public async Task<Unit> Handle(IncrementVersionWithGitIntegrationCommand request, CancellationToken cancellationToken)
+        public async Task<Unit> Handle(IncrementVersionWithGitHintsCommand request, CancellationToken cancellationToken)
         {
             var query = new GetCommitVersionInfosQuery { GitDirectory = request.GitDirectory, RemoteTarget = request.RemoteTarget, TipBranchName = request.BranchName };
             List<GitCommitVersionInfo> versionInfos = (await _mediator.Send(query, cancellationToken)).ToList();

--- a/src/Application/GitVersioning/Validators/IncrementVersionWithGitHintsValidator.cs
+++ b/src/Application/GitVersioning/Validators/IncrementVersionWithGitHintsValidator.cs
@@ -5,21 +5,21 @@ using System.IO;
 namespace Application.GitVersioning.Validators
 {
     /// <summary>
-    /// The validator responsible for enforcing business rules for the <see cref="IncrementVersionWithGitIntegrationCommand"/>.
+    /// The validator responsible for enforcing business rules for the <see cref="IncrementVersionWithGitHintsCommand"/>.
     /// </summary>
-    public class IncrementVersionWithGitIntegrationValidator : AbstractValidator<IncrementVersionWithGitIntegrationCommand>
+    public class IncrementVersionWithGitHintsIntegrationValidator : AbstractValidator<IncrementVersionWithGitHintsCommand>
     {
         /// <summary>
         /// Default Constructor
         /// </summary>
-        public IncrementVersionWithGitIntegrationValidator()
+        public IncrementVersionWithGitHintsIntegrationValidator()
         {
             RuleFor(x => x.GitDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.");
             RuleFor(x => x.GitDirectory).Must(x => Directory.Exists(Path.Join(x, ".git"))).WithMessage("Must be a valid .git directory.");
             RuleFor(x => x.CommitAuthorEmail).NotNull().NotEmpty();
             RuleFor(x => x.BranchName).NotNull().NotEmpty();
 
-            RuleFor(x => x.TargetDirectory).Must(x => Directory.Exists(x)).WithMessage("Must be a valid directory.")
+            RuleFor(x => x.TargetDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.")
                 .When(x => !string.IsNullOrWhiteSpace(x.TargetDirectory));
         }
     }

--- a/src/Application/GitVersioning/Validators/IncrementVersionWithGitValidator.cs
+++ b/src/Application/GitVersioning/Validators/IncrementVersionWithGitValidator.cs
@@ -1,23 +1,25 @@
 ﻿using Application.GitVersioning.Commands;
+using Domain.Enumerations;
 using FluentValidation;
 using System.IO;
 
 namespace Application.GitVersioning.Validators
 {
     /// <summary>
-    /// The validator responsible for enforcing business rules for the <see cref="IncrementVersionWithGitHintsCommand"/>.
+    /// The validator responsible for enforcing business rules for the <see cref="IncrementVersionWithGitCommand"/>.
     /// </summary>
-    public class IncrementVersionWithGitHintsValidator : AbstractValidator<IncrementVersionWithGitHintsCommand>
+    public class IncrementVersionWithGitValidator : AbstractValidator<IncrementVersionWithGitCommand>
     {
         /// <summary>
         /// Default Constructor
         /// </summary>
-        public IncrementVersionWithGitHintsValidator()
+        public IncrementVersionWithGitValidator()
         {
             RuleFor(x => x.GitDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.");
             RuleFor(x => x.GitDirectory).Must(x => Directory.Exists(Path.Join(x, ".git"))).WithMessage("Must be a valid .git directory.");
             RuleFor(x => x.CommitAuthorEmail).NotNull().NotEmpty();
             RuleFor(x => x.BranchName).NotNull().NotEmpty();
+            RuleFor(x => x.VersionIncrement).NotEqual(VersionIncrement.Unknown);
 
             RuleFor(x => x.TargetDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.")
                 .When(x => !string.IsNullOrWhiteSpace(x.TargetDirectory));

--- a/src/Presentation.Console/Commands/App.cs
+++ b/src/Presentation.Console/Commands/App.cs
@@ -6,7 +6,7 @@ namespace Presentation.Console.Commands
     /// The versioning commandline application.
     /// </summary>
     [Command("dotnet-version")]
-    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGit))]
+    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGitHints))]
     public class App
     {
         /// <summary>

--- a/src/Presentation.Console/Commands/App.cs
+++ b/src/Presentation.Console/Commands/App.cs
@@ -6,7 +6,7 @@ namespace Presentation.Console.Commands
     /// The versioning commandline application.
     /// </summary>
     [Command("dotnet-version")]
-    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGitHints))]
+    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGit), typeof(IncrementVersionWithGitHints))]
     public class App
     {
         /// <summary>

--- a/src/Presentation.Console/Commands/IncrementVersion.cs
+++ b/src/Presentation.Console/Commands/IncrementVersion.cs
@@ -53,7 +53,7 @@ namespace Presentation.Console.Commands
         /// <summary>
         /// Determines whether beta mode should be exited.
         /// </summary>
-        [Option(Description = "Determines whether beta mode should be exited.")]
+        [Option(Description = "Determines whether beta mode should be exited. This will set the version to 1.0.0 if the version was lower.")]
         public bool ExitBeta { get; set; }
 
         // ReSharper disable once UnusedMember.Local

--- a/src/Presentation.Console/Commands/IncrementVersionWithGit.cs
+++ b/src/Presentation.Console/Commands/IncrementVersionWithGit.cs
@@ -1,0 +1,102 @@
+﻿using Application.GitVersioning.Commands;
+using Domain.Enumerations;
+using McMaster.Extensions.CommandLineUtils;
+using MediatR;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Presentation.Console.Commands
+{
+    /// <summary>
+    /// Increment versions in csproj files with git integration.
+    /// </summary>
+    [Command(Description = "Increment versions in csproj files with git integration.")]
+    public class IncrementVersionWithGit
+    {
+        private readonly IMediator _mediator;
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        /// <param name="mediator">An abstraction for accessing application behaviors.</param>
+#pragma warning disable 8618
+        public IncrementVersionWithGit(IMediator mediator)
+#pragma warning restore 8618
+        {
+            _mediator = mediator;
+            RemoteTarget = "origin";
+            AuthorEmail = "tool@versioning.net";
+        }
+
+        /// <summary>
+        /// The directory containing the .git folder.
+        /// </summary>
+        [Option(Description = "The directory containing the .git folder.")]
+        [Required]
+        public string GitDirectory { get; set; }
+
+        /// <summary>
+        /// The directory to use for file versioning. Defaults to the GitDirectory if not provided.
+        /// </summary>
+        [Option(ShortName = "d", Description = "The directory to use for file versioning. Defaults to the GitDirectory if not provided.")]
+        public string TargetDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The search option to use with the <see cref="TargetDirectory"/>. Defaults to <see cref="SearchOption.AllDirectories"/>.
+        /// </summary>
+        [Option(Description = "The search option to use with the target directory. Defaults to AllDirectories.")]
+        [AllowedValues("AllDirectories", "TopDirectoryOnly", IgnoreCase = true)]
+        public SearchOption SearchOption { get; set; } = SearchOption.AllDirectories;
+
+        /// <summary>
+        /// The git remote target. Defaults to 'origin'.
+        /// </summary>
+        [Option(ShortName = "t", Description = "The git remote target. Defaults to 'origin'.")]
+        public string RemoteTarget { get; set; }
+
+        /// <summary>
+        /// The name of the branch to update.
+        /// </summary>
+        [Option(Description = "The name of the branch to update.")]
+        [Required]
+        public string BranchName { get; set; }
+
+        /// <summary>
+        /// The git commit author's email address.
+        /// </summary>
+        [Option(Description = "The git commit author's email address.")]
+        public string AuthorEmail { get; set; }
+
+        /// <summary>
+        /// Indicates how to increment the version.
+        /// </summary>
+        [Option(Description = "Indicates how to increment the version.")]
+        [Required]
+        public VersionIncrement VersionIncrement { get; set; } = VersionIncrement.None;
+
+        /// <summary>
+        /// Determines whether beta mode should be exited.
+        /// </summary>
+        [Option(Description = "Determines whether beta mode should be exited. This will set the version to 1.0.0 if the version was lower.")]
+        public bool ExitBeta { get; set; }
+
+        // ReSharper disable once UnusedMember.Local
+        private async Task OnExecuteAsync()
+        {
+            var command = new IncrementVersionWithGitCommand
+            {
+                GitDirectory = GitDirectory,
+                TargetDirectory = TargetDirectory,
+                SearchOption = SearchOption,
+                CommitAuthorEmail = AuthorEmail,
+                RemoteTarget = RemoteTarget,
+                BranchName = BranchName,
+                VersionIncrement = VersionIncrement,
+                ExitBeta = ExitBeta
+            };
+            await _mediator.Send(command, CancellationToken.None);
+        }
+    }
+}

--- a/src/Presentation.Console/Commands/IncrementVersionWithGitHints.cs
+++ b/src/Presentation.Console/Commands/IncrementVersionWithGitHints.cs
@@ -1,4 +1,4 @@
-﻿using Application.GitVersioning.Commands;
+using Application.GitVersioning.Commands;
 using McMaster.Extensions.CommandLineUtils;
 using MediatR;
 using System.ComponentModel.DataAnnotations;
@@ -9,10 +9,10 @@ using System.Threading.Tasks;
 namespace Presentation.Console.Commands
 {
     /// <summary>
-    /// Increment versions in csproj files with git integration.
+    /// Increment versions in csproj files with git integration based on git commit messages.
     /// </summary>
-    [Command]
-    public class IncrementVersionWithGit
+    [Command(Description = "Increment versions in csproj files with git integration based on git commit messages.")]
+    public class IncrementVersionWithGitHints
     {
         private readonly IMediator _mediator;
 
@@ -21,7 +21,7 @@ namespace Presentation.Console.Commands
         /// </summary>
         /// <param name="mediator">An abstraction for accessing application behaviors.</param>
 #pragma warning disable 8618
-        public IncrementVersionWithGit(IMediator mediator)
+        public IncrementVersionWithGitHints(IMediator mediator)
 #pragma warning restore 8618
         {
             _mediator = mediator;
@@ -71,7 +71,7 @@ namespace Presentation.Console.Commands
         // ReSharper disable once UnusedMember.Local
         private async Task OnExecuteAsync()
         {
-            var command = new IncrementVersionWithGitIntegrationCommand
+            var command = new IncrementVersionWithGitHintsCommand
             {
                 GitDirectory = GitDirectory,
                 TargetDirectory = TargetDirectory,

--- a/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHandlerTests.cs
+++ b/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHandlerTests.cs
@@ -1,0 +1,140 @@
+﻿using Application.AssemblyVersioning.Commands;
+using Application.GitVersioning.Commands;
+using Application.GitVersioning.Handlers;
+using Application.GitVersioning.Queries;
+using Application.Interfaces;
+using Domain.Entities;
+using MediatR;
+using Moq;
+using Semver;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Domain.Enumerations;
+using Xunit;
+using System.Linq;
+
+namespace Business.Tests.GitVersioning
+{
+    public class IncrementVersionWithGitHandlerTests
+    {
+        private List<GitCommit> Commits {get; } = new()
+        {
+            new GitCommit("27d8879","fake(Build): Updated build.yml to target the template solution file [skip hint]", new List<GitCommitFileInfo>()),
+            new GitCommit("27d8880","build(Pipeline): Downgraded to .net core 3.1 from 5 [skip ci]", new List<GitCommitFileInfo>()),
+            new GitCommit("27d8881","ci(Versioning): Increment version 0.0.0 -> 0.0.0 [skip ci] [skip hint]", new List<GitCommitFileInfo>())
+        };
+        
+        [Fact]
+        public async Task Handler_ExitsWhen_IncrementIsNone()
+        {
+            // Arrange
+            var mediator = new Mock<IMediator>();
+            var gitService = new Mock<IGitService>();
+            var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
+
+            mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
+            var sut = new IncrementVersionWithGitHandler(mediator.Object, gitService.Object, assemblyVersioningService.Object);
+
+            // Act
+            await sut.Handle(new IncrementVersionWithGitCommand(), CancellationToken.None);
+
+            // Assert
+            mediator.Verify(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None), Times.Never);
+            gitService.Verify(x => x.GetCommits(It.IsAny<string>()), Times.Never);
+            assemblyVersioningService.Verify(x => x.GetLatestAssemblyVersion(It.IsAny<string>(), It.IsAny<SearchOption>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handler_ExitsWhen_IncrementIsUnknown()
+        {
+            // Arrange
+            var mediator = new Mock<IMediator>();
+            var gitService = new Mock<IGitService>();
+            var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
+
+            mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
+            var sut = new IncrementVersionWithGitHandler(mediator.Object, gitService.Object, assemblyVersioningService.Object);
+
+            // Act
+            await sut.Handle(new IncrementVersionWithGitCommand(), CancellationToken.None);
+
+            // Assert
+            mediator.Verify(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None), Times.Never);
+            gitService.Verify(x => x.GetCommits(It.IsAny<string>()), Times.Never);
+            assemblyVersioningService.Verify(x => x.GetLatestAssemblyVersion(It.IsAny<string>(), It.IsAny<SearchOption>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task TargetDirectory_SetToGitDirectory_WhenEmpty()
+        {
+            // Arrange
+            var request = new IncrementVersionWithGitCommand
+            {
+                GitDirectory = "C:\\Temp",
+                TargetDirectory = null,
+                SearchOption = SearchOption.AllDirectories,
+                CommitAuthorEmail = "support@versioning.net",
+                BranchName = "test",
+                RemoteTarget = "origin",
+                VersionIncrement = VersionIncrement.Minor
+            };
+            var assemblyVersion = new SemVersion(0);
+            var mediator = new Mock<IMediator>();
+            var gitService = new Mock<IGitService>();
+            var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
+
+            mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
+            gitService.Setup(x => x.GetCommits(It.IsAny<string>())).Returns(Commits);
+
+            assemblyVersioningService.Setup(x => x.GetLatestAssemblyVersion(request.GitDirectory, request.SearchOption)).Returns(assemblyVersion);
+            var sut = new IncrementVersionWithGitHandler(mediator.Object, gitService.Object, assemblyVersioningService.Object);
+
+            // Act
+            await sut.Handle(request, CancellationToken.None);
+
+            // Assert
+            assemblyVersioningService.Verify(x => x.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Handler_CallsDependencies()
+        {
+            // Arrange
+            var request = new IncrementVersionWithGitCommand
+            {
+                GitDirectory = "C:\\Temp",
+                TargetDirectory = "C:\\Temp\\Sub",
+                SearchOption = SearchOption.AllDirectories,
+                CommitAuthorEmail = "support@versioning.net",
+                BranchName = "test",
+                RemoteTarget = "origin",
+                VersionIncrement = VersionIncrement.Minor
+            };
+            var commit = Commits.First(x => x.Subject == "ci(Versioning): Increment version 0.0.0 -> 0.0.0 [skip ci] [skip hint]");
+            var assemblyVersion = new SemVersion(0);
+            var mediator = new Mock<IMediator>();
+            var gitService = new Mock<IGitService>();
+            var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
+
+            mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
+            gitService.Setup(x => x.GetCommits(It.IsAny<string>())).Returns(Commits);
+
+            assemblyVersioningService.Setup(x => x.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption)).Returns(assemblyVersion);
+            var sut = new IncrementVersionWithGitHandler(mediator.Object, gitService.Object, assemblyVersioningService.Object);
+
+            // Act
+            await sut.Handle(request, CancellationToken.None);
+
+            // Assert
+            mediator.Verify(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None), Times.Once);
+            assemblyVersioningService.Verify(x => x.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption), Times.Exactly(2));
+            gitService.Verify(x => x.CommitChanges(request.GitDirectory, commit.Subject, request.CommitAuthorEmail), Times.Once);
+            gitService.Verify(x => x.GetCommits(request.GitDirectory), Times.Once);
+            gitService.Verify(x => x.CreateTag(request.GitDirectory, $"v{assemblyVersion}", commit.Id), Times.Once);
+            gitService.Verify(x => x.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/heads/{request.BranchName}"), Times.Once);
+            gitService.Verify(x => x.PushRemote(request.GitDirectory, request.RemoteTarget, $"refs/tags/v{assemblyVersion}"), Times.Once);
+        }
+    }
+}

--- a/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHintsHandlerTests.cs
+++ b/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHintsHandlerTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Business.Tests.GitVersioning
 {
-    public class IncrementVersionWithGitIntegrationHandlerTests
+    public class IncrementVersionWithGitHintsHandlerTests
     {
         private List<GitCommit> Commits {get; } = new List<GitCommit>
         {
@@ -42,15 +42,15 @@ namespace Business.Tests.GitVersioning
             var gitService = new Mock<IGitService>();
             var gitVersioningService = new Mock<IGitVersioningService>();
             var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
-            var logger = new NullLogger<IncrementVersionWithGitIntegrationHandler>();
+            var logger = new NullLogger<IncrementVersionWithGitHintsHandler>();
 
             gitVersioningService.Setup(x => x.DeterminePriorityIncrement(It.IsAny<IEnumerable<VersionIncrement>>())).Returns(VersionIncrement.None);
             mediator.Setup(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None)).ReturnsAsync(new List<GitCommitVersionInfo>());
             mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
-            var sut = new IncrementVersionWithGitIntegrationHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
+            var sut = new IncrementVersionWithGitHintsHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
 
             // Act
-            await sut.Handle(new IncrementVersionWithGitIntegrationCommand(), CancellationToken.None);
+            await sut.Handle(new IncrementVersionWithGitHintsCommand(), CancellationToken.None);
 
             // Assert
             mediator.Verify(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None), Times.Once);
@@ -68,15 +68,15 @@ namespace Business.Tests.GitVersioning
             var gitService = new Mock<IGitService>();
             var gitVersioningService = new Mock<IGitVersioningService>();
             var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
-            var logger = new NullLogger<IncrementVersionWithGitIntegrationHandler>();
+            var logger = new NullLogger<IncrementVersionWithGitHintsHandler>();
 
             gitVersioningService.Setup(x => x.DeterminePriorityIncrement(It.IsAny<IEnumerable<VersionIncrement>>())).Returns(VersionIncrement.Unknown);
             mediator.Setup(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None)).ReturnsAsync(new List<GitCommitVersionInfo>());
             mediator.Setup(x => x.Send(It.IsAny<IncrementAssemblyVersionCommand>(), CancellationToken.None)).ReturnsAsync(Unit.Value);
-            var sut = new IncrementVersionWithGitIntegrationHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
+            var sut = new IncrementVersionWithGitHintsHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
 
             // Act
-            await sut.Handle(new IncrementVersionWithGitIntegrationCommand(), CancellationToken.None);
+            await sut.Handle(new IncrementVersionWithGitHintsCommand(), CancellationToken.None);
 
             // Assert
             mediator.Verify(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None), Times.Once);
@@ -90,7 +90,7 @@ namespace Business.Tests.GitVersioning
         public async Task TargetDirectory_SetToGitDirectory_WhenEmpty()
         {
             // Arrange
-            var request = new IncrementVersionWithGitIntegrationCommand
+            var request = new IncrementVersionWithGitHintsCommand
             {
                 GitDirectory = "C:\\Temp",
                 TargetDirectory = null,
@@ -105,7 +105,7 @@ namespace Business.Tests.GitVersioning
             var gitService = new Mock<IGitService>();
             var gitVersioningService = new Mock<IGitVersioningService>();
             var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
-            var logger = new NullLogger<IncrementVersionWithGitIntegrationHandler>();
+            var logger = new NullLogger<IncrementVersionWithGitHintsHandler>();
 
             gitVersioningService.Setup(x => x.DeterminePriorityIncrement(It.IsAny<IEnumerable<VersionIncrement>>())).Returns(VersionIncrement.Minor);
             mediator.Setup(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None)).ReturnsAsync(new List<GitCommitVersionInfo>());
@@ -113,7 +113,7 @@ namespace Business.Tests.GitVersioning
 
             gitService.Setup(x => x.GetCommits(It.IsAny<string>())).Returns(Commits);
             assemblyVersioningService.Setup(x => x.GetLatestAssemblyVersion(request.GitDirectory, request.SearchOption)).Returns(assemblyVersion);
-            var sut = new IncrementVersionWithGitIntegrationHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
+            var sut = new IncrementVersionWithGitHintsHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
 
             // Act
             await sut.Handle(request, CancellationToken.None);
@@ -126,7 +126,7 @@ namespace Business.Tests.GitVersioning
         public async Task Handler_CallsDependencies()
         {
             // Arrange
-            var request = new IncrementVersionWithGitIntegrationCommand
+            var request = new IncrementVersionWithGitHintsCommand
             {
                 GitDirectory = "C:\\Temp",
                 TargetDirectory = "C:\\Temp\\Sub",
@@ -141,7 +141,7 @@ namespace Business.Tests.GitVersioning
             var gitService = new Mock<IGitService>();
             var gitVersioningService = new Mock<IGitVersioningService>();
             var assemblyVersioningService = new Mock<IAssemblyVersioningService>();
-            var logger = new NullLogger<IncrementVersionWithGitIntegrationHandler>();
+            var logger = new NullLogger<IncrementVersionWithGitHintsHandler>();
 
             gitVersioningService.Setup(x => x.DeterminePriorityIncrement(It.IsAny<IEnumerable<VersionIncrement>>())).Returns(VersionIncrement.Minor);
             mediator.Setup(x => x.Send(It.IsAny<GetCommitVersionInfosQuery>(), CancellationToken.None)).ReturnsAsync(new List<GitCommitVersionInfo>());
@@ -149,7 +149,7 @@ namespace Business.Tests.GitVersioning
 
             gitService.Setup(x => x.GetCommits(It.IsAny<string>())).Returns(Commits);
             assemblyVersioningService.Setup(x => x.GetLatestAssemblyVersion(request.TargetDirectory, request.SearchOption)).Returns(assemblyVersion);
-            var sut = new IncrementVersionWithGitIntegrationHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
+            var sut = new IncrementVersionWithGitHintsHandler(mediator.Object, gitService.Object, gitVersioningService.Object, assemblyVersioningService.Object, logger);
 
             // Act
             await sut.Handle(request, CancellationToken.None);

--- a/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHintsValidatorTests.cs
+++ b/tst/Business.Tests/GitVersioning/IncrementVersionWithGitHintsValidatorTests.cs
@@ -10,14 +10,14 @@ using Xunit;
 
 namespace Business.Tests.GitVersioning
 {
-    public class IncrementVersionWithGitIntegrationValidatorTests
+    public class IncrementVersionWithGitHintsValidatorTests
     {
         [Fact]
         public void Validator_Fails_OnInvalidDirectory()
         {
             // Arrange
             const string invalidDirectory = "X:\\Temp";
-            var sut = new IncrementVersionWithGitIntegrationValidator();
+            var sut = new IncrementVersionWithGitHintsIntegrationValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.GitDirectory, invalidDirectory).WithErrorMessage("Must be a valid directory.");
@@ -28,7 +28,7 @@ namespace Business.Tests.GitVersioning
         {
             // Arrange
             string invalidDirectory = Path.GetTempPath();
-            var sut = new IncrementVersionWithGitIntegrationValidator();
+            var sut = new IncrementVersionWithGitHintsIntegrationValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.GitDirectory, invalidDirectory).WithErrorMessage("Must be a valid .git directory.");
@@ -44,7 +44,7 @@ namespace Business.Tests.GitVersioning
             string projectDir = Directory.GetParent(binDir)!.FullName;
             string tstDir = Directory.GetParent(projectDir)!.FullName;
             string slnDir = Directory.GetParent(tstDir)!.FullName;
-            var sut = new IncrementVersionWithGitIntegrationValidator();
+            var sut = new IncrementVersionWithGitHintsIntegrationValidator();
 
             // Act & Assert
             sut.ShouldNotHaveValidationErrorFor(x => x.GitDirectory, slnDir);
@@ -55,7 +55,7 @@ namespace Business.Tests.GitVersioning
         {
             // Arrange
             string invalidDirectory = "invalid directory";
-            var sut = new IncrementVersionWithGitIntegrationValidator();
+            var sut = new IncrementVersionWithGitHintsIntegrationValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.TargetDirectory, invalidDirectory).WithErrorMessage("Must be a valid directory.");
@@ -65,7 +65,7 @@ namespace Business.Tests.GitVersioning
         public void Validator_HasCorrectValidators()
         {
             // Arrange
-            var sut = new IncrementVersionWithGitIntegrationValidator();
+            var sut = new IncrementVersionWithGitHintsIntegrationValidator();
 
             // Act & Assert
             sut.ShouldHaveRules(x => x.CommitAuthorEmail,

--- a/tst/Business.Tests/GitVersioning/IncrementVersionWithGitValidatorTests.cs
+++ b/tst/Business.Tests/GitVersioning/IncrementVersionWithGitValidatorTests.cs
@@ -6,18 +6,30 @@ using FluentValidation.Validators.UnitTestExtension.Core;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using System.IO;
 using System.Reflection;
+using Domain.Enumerations;
 using Xunit;
 
 namespace Business.Tests.GitVersioning
 {
-    public class IncrementVersionWithGitHintsValidatorTests
+    public class IncrementVersionWithGitValidatorTests
     {
+        [Fact]
+        public void Validator_Fails_OnInvalidVersionIncrement()
+        {
+            // Arrange
+            VersionIncrement invalidIncrement = VersionIncrement.Unknown;
+            var sut = new IncrementVersionWithGitValidator();
+
+            // Act & Assert
+            sut.ShouldHaveValidationErrorFor(x => x.VersionIncrement, invalidIncrement).WithErrorMessage("'Version Increment' must not be equal to 'Unknown'.");
+        }
+        
         [Fact]
         public void Validator_Fails_OnInvalidDirectory()
         {
             // Arrange
             const string invalidDirectory = "X:\\Temp";
-            var sut = new IncrementVersionWithGitHintsValidator();
+            var sut = new IncrementVersionWithGitValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.GitDirectory, invalidDirectory).WithErrorMessage("Must be a valid directory.");
@@ -28,7 +40,7 @@ namespace Business.Tests.GitVersioning
         {
             // Arrange
             string invalidDirectory = Path.GetTempPath();
-            var sut = new IncrementVersionWithGitHintsValidator();
+            var sut = new IncrementVersionWithGitValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.GitDirectory, invalidDirectory).WithErrorMessage("Must be a valid .git directory.");
@@ -44,7 +56,7 @@ namespace Business.Tests.GitVersioning
             string projectDir = Directory.GetParent(binDir)!.FullName;
             string tstDir = Directory.GetParent(projectDir)!.FullName;
             string slnDir = Directory.GetParent(tstDir)!.FullName;
-            var sut = new IncrementVersionWithGitHintsValidator();
+            var sut = new IncrementVersionWithGitValidator();
 
             // Act & Assert
             sut.ShouldNotHaveValidationErrorFor(x => x.GitDirectory, slnDir);
@@ -55,7 +67,7 @@ namespace Business.Tests.GitVersioning
         {
             // Arrange
             string invalidDirectory = "invalid directory";
-            var sut = new IncrementVersionWithGitHintsValidator();
+            var sut = new IncrementVersionWithGitValidator();
 
             // Act & Assert
             sut.ShouldHaveValidationErrorFor(x => x.TargetDirectory, invalidDirectory).WithErrorMessage("Must be a valid directory.");
@@ -65,7 +77,7 @@ namespace Business.Tests.GitVersioning
         public void Validator_HasCorrectValidators()
         {
             // Arrange
-            var sut = new IncrementVersionWithGitHintsValidator();
+            var sut = new IncrementVersionWithGitValidator();
 
             // Act & Assert
             sut.ShouldHaveRules(x => x.CommitAuthorEmail,

--- a/tst/Integration.Tests/Handlers/IncrementVersionWithGitHintsHandlerTests.cs
+++ b/tst/Integration.Tests/Handlers/IncrementVersionWithGitHintsHandlerTests.cs
@@ -11,11 +11,11 @@ using Xunit;
 
 namespace Integration.Tests.Handlers
 {
-    public class IncrementVersionWithGitIntegrationHandlerTests : GitSetup, IClassFixture<Orchestrator>
+    public class IncrementVersionWithGitHintsHandlerTests : GitSetup, IClassFixture<Orchestrator>
     {
         private readonly IServiceProvider _serviceProvider;
 
-        public IncrementVersionWithGitIntegrationHandlerTests(Orchestrator orchestrator)
+        public IncrementVersionWithGitHintsHandlerTests(Orchestrator orchestrator)
         {
             _serviceProvider = orchestrator.BuildServiceProvider();
         }
@@ -36,10 +36,10 @@ namespace Integration.Tests.Handlers
             var gitService = _serviceProvider.GetRequiredService<IGitService>();
             var gitVersioningService = _serviceProvider.GetRequiredService<IGitVersioningService>();
             var versioningService = _serviceProvider.GetRequiredService<IAssemblyVersioningService>();
-            var logger = _serviceProvider.GetRequiredService<ILogger<IncrementVersionWithGitIntegrationHandler>>();
-            var sut = new IncrementVersionWithGitIntegrationHandler(mediator, gitService, gitVersioningService, versioningService, logger);
+            var logger = _serviceProvider.GetRequiredService<ILogger<IncrementVersionWithGitHintsHandler>>();
+            var sut = new IncrementVersionWithGitHintsHandler(mediator, gitService, gitVersioningService, versioningService, logger);
 
-            var command = new IncrementVersionWithGitIntegrationCommand
+            var command = new IncrementVersionWithGitHintsCommand
             {
                 GitDirectory = TestRepoDirectory,
                 BranchName = "main",

--- a/tst/Presentation.Console.Tests/StartupTests.cs
+++ b/tst/Presentation.Console.Tests/StartupTests.cs
@@ -46,6 +46,19 @@ namespace Presentation.Console.Tests
         }
 
         [Fact]
+        public async Task CanStartupHelp_IncrementVersionWithGit()
+        {
+            // Arrange
+            var args = new[] { "increment-version-with-git", "--help"};
+
+            // Act
+            int resultCode = await Program.Main(args);
+
+            // Assert
+            Assert.Equal(0, resultCode);
+        }
+
+        [Fact]
         public async Task CanStartupHelp_IncrementVersionWithGitHints()
         {
             // Arrange
@@ -63,6 +76,19 @@ namespace Presentation.Console.Tests
         {
             // Arrange
             var args = new[] { "increment-version", "-d", "fake directory", "-v", VersionIncrement.Patch.ToString() };
+
+            // Act
+            int resultCode = await Program.Main(args);
+
+            // Assert
+            Assert.Equal(-1, resultCode);
+        }
+
+        [Fact]
+        public async Task CanStartup_IncrementVersionWithGit()
+        {
+            // Arrange
+            var args = new[] { "increment-version-with-git", "-g", "fake directory", "-a", "devops@versioning.net", "-b", "main", "-v", VersionIncrement.Patch.ToString() };
 
             // Act
             int resultCode = await Program.Main(args);

--- a/tst/Presentation.Console.Tests/StartupTests.cs
+++ b/tst/Presentation.Console.Tests/StartupTests.cs
@@ -46,10 +46,10 @@ namespace Presentation.Console.Tests
         }
 
         [Fact]
-        public async Task CanStartupHelp_IncrementVersionWithGit()
+        public async Task CanStartupHelp_IncrementVersionWithGitHints()
         {
             // Arrange
-            var args = new[] { "increment-version-with-git", "--help"};
+            var args = new[] { "increment-version-with-git-hints", "--help"};
 
             // Act
             int resultCode = await Program.Main(args);
@@ -72,10 +72,10 @@ namespace Presentation.Console.Tests
         }
 
         [Fact]
-        public async Task CanStartup_IncrementVersionWithGit()
+        public async Task CanStartup_IncrementVersionWithGitHints()
         {
             // Arrange
-            var args = new[] { "increment-version-with-git", "-g", "fake directory", "-a", "devops@versioning.net", "-b", "main" };
+            var args = new[] { "increment-version-with-git-hints", "-g", "fake directory", "-a", "devops@versioning.net", "-b", "main" };
 
             // Act
             int resultCode = await Program.Main(args);


### PR DESCRIPTION
The command `increment-version-with-git` has been repurposed to allow support for manually supplying the version increment but still allowing for git integration. The previous behavior which utilized git commit messages to determine the version increment was removed and is now in the new command `increment-version-with-git-hints`.

Closes #27