### PR TITLE
fix(Commits): Adjusted regex pattern to be more flexible

### DIFF
--- a/src/Domain/Constants/RegexPatterns.cs
+++ b/src/Domain/Constants/RegexPatterns.cs
@@ -13,6 +13,6 @@
         /// <summary>
         /// Matches the commit message subject in a git log line.
         /// </summary>
-        public const string GitLogCommitSubject = @"(?<Type>\w{1,})\((?<Scope>[\w\s]{1,})\)\s*:\s*(?<Subject>[^\s].{1,})";
+        public const string GitLogCommitSubject = @"(?<Type>\w{1,})\((?<Scope>.*)\)\s*:\s*(?<Subject>[^\s].{1,})";
     }
 }

--- a/tst/Business.Tests/RegexPatternsTests.cs
+++ b/tst/Business.Tests/RegexPatternsTests.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Constants;
+﻿using System.Text;
+using Domain.Constants;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -22,21 +23,25 @@ namespace Business.Tests
         }
 
         [Theory]
-        [InlineData("test(Test): Added ability to test", true)]
-        [InlineData("test(Different Test): test", true)]
-        [InlineData("test(Different Test) : test", true)]
-        [InlineData("test(Different Test): ", false)]
-        [InlineData("(Different Test): test", false)]
-        public void MatchesCommitSubject(string commitId, bool expectedResult)
+        [InlineData("test(Default Test): Added ability to test", true, "test", "Default Test", "Added ability to test")]
+        [InlineData("test(Pre-Colon Space Test) : test", true, "test", "Pre-Colon Space Test", "test")]
+        [InlineData("test(Special.(Char-Te$t)): test", true, "test", "Special.(Char-Te$t)", "test")]
+        [InlineData("test(): No scope test", true, "test", "", "No scope test")]
+        [InlineData("test(Whitespace Subject Test): ", false)]
+        [InlineData("(No Type Test): test", false)]
+        public void MatchesCommitSubject(string commitId, bool expectedResult, string expectedType = "", string expectedScope = "", string expectedSubject = "")
         {
             // Arrange
             var sut = new Regex(RegexPatterns.GitLogCommitSubject);
 
             // Act
-            bool result = sut.IsMatch(commitId);
+            var match = sut.Match(commitId);
 
             // Act & Assert
-            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedResult, match.Success);
+            Assert.Equal(expectedType, match.Groups["Type"].Value);
+            Assert.Equal(expectedScope, match.Groups["Scope"].Value);
+            Assert.Equal(expectedSubject, match.Groups["Subject"].Value);
         }
     }
 }


### PR DESCRIPTION
* Fixed an issue where commits were not being  properly detected when they contained special characters such as a period
* Also increased the quality of the regex pattern tests

Closes #43