### PR TITLE
Make Test runable in VS and runable by any one

### DIFF
--- a/.github/workflows/dotnet.main.status.yml
+++ b/.github/workflows/dotnet.main.status.yml
@@ -34,7 +34,7 @@ jobs:
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
         GitHubActor: ${{ github.actor }}
-        GitHubAccessToken: ${{ GITHUBACCESSTOKEN }}
+        GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
         #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"
     - name: Codecov
       # You may pin to the exact commit or the version.

--- a/.github/workflows/dotnet.main.status.yml
+++ b/.github/workflows/dotnet.main.status.yml
@@ -33,9 +33,9 @@ jobs:
         --collect:"XPlat Code Coverage"
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
-        GitHubActor: ${{ github.actor }}
+        GitHubActor: ${{ github.repository_owner }}
         GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
-        #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"
+        #GitHubTestRepoAddress: "github.com/${{ github.repository }}.Tests.git"
     - name: Codecov
       # You may pin to the exact commit or the version.
       # uses: codecov/codecov-action@fcebab03f26c7530a22baa63f06b3e0515f0c7cd

--- a/.github/workflows/dotnet.main.status.yml
+++ b/.github/workflows/dotnet.main.status.yml
@@ -34,7 +34,7 @@ jobs:
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
         GitHubActor: ${{ github.actor }}
-        GitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        GitHubAccessToken: ${{ GITHUBACCESSTOKEN }}
         #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"
     - name: Codecov
       # You may pin to the exact commit or the version.

--- a/.github/workflows/dotnet.main.status.yml
+++ b/.github/workflows/dotnet.main.status.yml
@@ -33,8 +33,9 @@ jobs:
         --collect:"XPlat Code Coverage"
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
-        GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
-
+        GitHubActor: ${{ github.actor }}
+        GitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"
     - name: Codecov
       # You may pin to the exact commit or the version.
       # uses: codecov/codecov-action@fcebab03f26c7530a22baa63f06b3e0515f0c7cd

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,6 +35,6 @@ jobs:
         --collect:"XPlat Code Coverage"
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
-        GitHubActor: ${{ github.actor }}
+        GitHubActor: ${{ github.repository_owner }}
         GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
-        #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"
+        #GitHubTestRepoAddress: "github.com/${{ github.repository }}.Tests.git"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,4 +35,6 @@ jobs:
         --collect:"XPlat Code Coverage"
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
-        GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
+        GitHubActor: ${{ github.actor }}
+        GitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,5 +36,5 @@ jobs:
         -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       env:
         GitHubActor: ${{ github.actor }}
-        GitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        GitHubAccessToken: ${{ secrets.GITHUBACCESSTOKEN }}
         #GitHubTestRepoAddress: "github.com/${{ github.actor }}/${{ github.repository }}.Tests.git"

--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ MigrationBackup/
 
 # Azure Functions local settings file
 local.settings.json
+/tst/Integration.Tests/Setup/Local.cs

--- a/tst/Integration.Tests/Handlers/IncrementVersionWithGitHintsHandlerTests.cs
+++ b/tst/Integration.Tests/Handlers/IncrementVersionWithGitHintsHandlerTests.cs
@@ -27,8 +27,10 @@ namespace Integration.Tests.Handlers
             using var repo = new Repository(TestRepoDirectory);
             repo.Network.Remotes.Update("origin", updater =>
             {
-                var token = Environment.GetEnvironmentVariable("GitHubAccessToken");
-                var url = $"https://cbcrouse:{token}@github.com/cbcrouse/Versioning.NET.Tests.git";
+                var actor = Environment.GetEnvironmentVariable("GitHubActor") ?? EnvironmentVariable.local.GitHubActor;
+                var token = Environment.GetEnvironmentVariable("GitHubAccessToken") ?? EnvironmentVariable.local.GitHubAccessToken;
+                var testRepo = Environment.GetEnvironmentVariable("GitHubTestRepoAddress") ?? EnvironmentVariable.local.GitHubTestRepoAddress ?? $"github.com/{actor}/Versioning.NET.Tests.git";
+                var url = $"https://{actor}:{token}@{testRepo}";
                 updater.Url = url;
                 updater.PushUrl = url;
             });

--- a/tst/Integration.Tests/Services/GitIntegrationTests.LibGit2ServiceTests.cs
+++ b/tst/Integration.Tests/Services/GitIntegrationTests.LibGit2ServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Entities;
 using Infrastructure.Services;
+using Integration.Tests.Setup;
 using LibGit2Sharp;
 using System;
 using System.IO;
@@ -150,8 +151,10 @@ namespace Integration.Tests.Services
             using var repo = new Repository(TestRepoDirectory);
             repo.Network.Remotes.Update("origin", updater =>
             {
-                var token = Environment.GetEnvironmentVariable("GitHubAccessToken");
-                var url = $"https://cbcrouse:{token}@github.com/cbcrouse/Versioning.NET.Tests.git";
+                var actor = Environment.GetEnvironmentVariable("GitHubActor") ?? EnvironmentVariable.local.GitHubActor;
+                var token = Environment.GetEnvironmentVariable("GitHubAccessToken") ?? EnvironmentVariable.local.GitHubAccessToken;
+                var testRepo = Environment.GetEnvironmentVariable("GitHubTestRepoAddress") ?? EnvironmentVariable.local.GitHubTestRepoAddress ?? $"github.com/{actor}/Versioning.NET.Tests.git";
+                var url = $"https://{actor}:{token}@{testRepo}";
                 updater.Url = url;
                 updater.PushUrl = url;
             });
@@ -183,8 +186,10 @@ namespace Integration.Tests.Services
             using var repo = new Repository(TestRepoDirectory);
             repo.Network.Remotes.Update("origin", updater =>
             {
-                var token = Environment.GetEnvironmentVariable("GitHubAccessToken");
-                var url = $"https://cbcrouse:{token}@github.com/cbcrouse/Versioning.NET.Tests.git";
+                var actor = Environment.GetEnvironmentVariable("GitHubActor") ?? EnvironmentVariable.local.GitHubActor;
+                var token = Environment.GetEnvironmentVariable("GitHubAccessToken") ?? EnvironmentVariable.local.GitHubAccessToken;
+                var testRepo = Environment.GetEnvironmentVariable("GitHubTestRepoAddress") ?? EnvironmentVariable.local.GitHubTestRepoAddress ?? $"github.com/{actor}/Versioning.NET.Tests.git";
+                var url = $"https://{actor}:{token}@{testRepo}";
                 updater.Url = url;
                 updater.PushUrl = url;
             });

--- a/tst/Integration.Tests/Setup/EnvironmentVariable.cs
+++ b/tst/Integration.Tests/Setup/EnvironmentVariable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Integration.Tests.Setup
+{
+    partial class EnvironmentVariable
+    {
+        public static EnvironmentVariable local = new EnvironmentVariable();
+
+        public string GitHubActor = null;
+        public string GitHubAccessToken = null;
+        public string GitHubTestRepoAddress = null;
+    }
+}

--- a/tst/Integration.Tests/Setup/GitSetup.cs
+++ b/tst/Integration.Tests/Setup/GitSetup.cs
@@ -19,8 +19,10 @@ namespace Integration.Tests.Setup
 
         private void CloneTestRepository()
         {
+            var actor = Environment.GetEnvironmentVariable("GitHubActor") ?? EnvironmentVariable.local.GitHubActor;
+            var testRepo = Environment.GetEnvironmentVariable("GitHubTestRepoAddress") ?? EnvironmentVariable.local.GitHubTestRepoAddress ?? $"github.com/{actor}/Versioning.NET.Tests.git";
             CreateTempDirectory();
-            var gitPath = Repository.Clone("https://github.com/cbcrouse/Versioning.NET.Tests", _testRepoParentDirectory);
+            var gitPath = Repository.Clone($"https://{testRepo}", _testRepoParentDirectory);
             TestRepoDirectory = Directory.GetParent(gitPath)!.Parent!.FullName;
         }
 


### PR DESCRIPTION
I make some change to your test so the test can be run by anyone.
To do so, the person needs to clone the test repository and create a GITHUBACCESSTOKEN  to the for the test repository.

If he will run the test inside Visual Studio he needs to add a Local.cs file in the setup folder of Integration.Tests with this code:
 ```
partial class EnvironmentVariable
    {
        public EnvironmentVariable()
        {
            this.GitHubActor = {{GitHub.Actor}}; // the name of the account how own the GITHUBACCESSTOKEN
            this.GitHubAccessToken = {{GITHUBACCESSTOKEN}}; // the GITHUBACCESSTOKEN for the test repository
            this.GitHubTestRepoAddress = {{TestRepoAddress}}; // only needed if the test repos is not 'github.com/{actor}/Versioning.NET.Tests.git'
        }
    }
```