### PR TITLE
Created command Increment version with custom git hints

### DIFF
--- a/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
@@ -89,7 +89,7 @@ namespace Application.GitVersioning.Commands
         /// <summary>
         /// Gets or sets the list of commit's types how will create a minor increment
         /// </summary>
-        public IEnumerable<string> MinorTypeHints { get; set; } = new List<string> { "feat" };
+        public IEnumerable<string> MinorTypeHints { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the list of commit's scopes how will create a minor increment
@@ -104,7 +104,7 @@ namespace Application.GitVersioning.Commands
         /// <summary>
         /// Gets or sets the list of commit's types how will create a patch increment
         /// </summary>
-        public IEnumerable<string> PatchTypeHints { get; set; } = new List<string> { "fix", "build", "config", "docs", "perf", "refactor", "resolve", "style", "test", "ci", "feat" };
+        public IEnumerable<string> PatchTypeHints { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the list of commit's scopes how will create a patch increment

--- a/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
@@ -1,0 +1,124 @@
+﻿using Domain.Enumerations;
+using MediatR;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Application.GitVersioning.Commands
+{
+    /// <summary>
+    /// The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration, with custom hints.
+    /// </summary>
+    public class IncrementVersionWithCustomGitHintsCommand : IRequest<Unit>
+    {
+        /// <summary>
+        /// Gets or sets the directory containing the .git folder.
+        /// </summary>
+        public string GitDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the directory to target for file versioning.
+        /// </summary>
+        public string TargetDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the search option to use with the <see cref="TargetDirectory"/>.
+        /// </summary>
+        public SearchOption SearchOption { get; set; } = SearchOption.AllDirectories;
+
+        /// <summary>
+        /// Gets or sets the author email to use when creating a commit.
+        /// </summary>
+        public string CommitAuthorEmail { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the git remote target. Defaults to 'origin'.
+        /// </summary>
+        public string RemoteTarget { get; set; } = "origin";
+
+        /// <summary>
+        /// Gets or sets the name of the branch to update.
+        /// </summary>
+        public string BranchName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether beta mode should be exited.
+        /// </summary>
+        public bool? ExitBeta { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the prefix value to use for the version tag in git. Defaults to 'v'.
+        /// </summary>
+        public string TagPrefix { get; set; } = "v";
+
+        /// <summary>
+        /// Gets or sets the suffix value to use for the version tag in git.
+        /// </summary>
+        public string TagSuffix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the list of commit's types how will create a none increment
+        /// </summary>
+        public IEnumerable<string> SkipTypeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's scopes how will create a none increment
+        /// </summary>
+        public IEnumerable<string> SkipScopeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's subjects hints how will create a none increment
+        /// </summary>
+        public IEnumerable<string> SkipSubjectHints { get; set; } = new List<string> { "[skip hint]" };
+
+        /// <summary>
+        /// Gets or sets the list of commit's types how will create a major increment
+        /// </summary>
+        public IEnumerable<string> MajorTypeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's scopes how will create a major increment
+        /// </summary>
+        public IEnumerable<string> MajorScopeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's subjects hints how will create a major increment
+        /// </summary>
+        public IEnumerable<string> MajorSubjectHints { get; set; } = new List<string> { "#breaking" };
+
+        /// <summary>
+        /// Gets or sets the list of commit's types how will create a minor increment
+        /// </summary>
+        public IEnumerable<string> MinorTypeHints { get; set; } = new List<string> { "feat" };
+
+        /// <summary>
+        /// Gets or sets the list of commit's scopes how will create a minor increment
+        /// </summary>
+        public IEnumerable<string> MinorScopeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's subjects hints how will create a minor increment
+        /// </summary>
+        public IEnumerable<string> MinorSubjectHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's types how will create a patch increment
+        /// </summary>
+        public IEnumerable<string> PatchTypeHints { get; set; } = new List<string> { "fix", "build", "config", "docs", "perf", "refactor", "resolve", "style", "test", "ci", "feat" };
+
+        /// <summary>
+        /// Gets or sets the list of commit's scopes how will create a patch increment
+        /// </summary>
+        public IEnumerable<string> PatchScopeHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of commit's subjects hints how will create a patch increment
+        /// </summary>
+        public IEnumerable<string> PatchSubjectHints { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the case insensitive for the git hints
+        /// </summary>
+        public bool CaseInsensitiveHints { get; set; } = false;
+    }
+}

--- a/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
+++ b/src/Application/GitVersioning/Commands/IncrementVersionWithCustomGitHintsCommand.cs
@@ -69,7 +69,7 @@ namespace Application.GitVersioning.Commands
         /// <summary>
         /// Gets or sets the list of commit's subjects hints how will create a none increment
         /// </summary>
-        public IEnumerable<string> SkipSubjectHints { get; set; } = new List<string> { "[skip hint]" };
+        public IEnumerable<string> SkipSubjectHints { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the list of commit's types how will create a major increment

--- a/src/Application/GitVersioning/Handlers/IncrementVersionWithCustomGitHintsHandler.cs
+++ b/src/Application/GitVersioning/Handlers/IncrementVersionWithCustomGitHintsHandler.cs
@@ -1,12 +1,9 @@
-﻿using Application.AssemblyVersioning.Commands;
-using Application.GitVersioning.Commands;
+﻿using Application.GitVersioning.Commands;
 using Application.GitVersioning.Queries;
-using Application.Interfaces;
 using Domain.Entities;
 using Domain.Enumerations;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Semver;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -20,30 +17,18 @@ namespace Application.GitVersioning.Handlers
     public class IncrementVersionWithCustomGitHintsHandler : IRequestHandler<IncrementVersionWithCustomGitHintsCommand, Unit>
     {
         private readonly IMediator _mediator;
-        private readonly IGitService _gitService;
-        private readonly IGitVersioningService _gitVersioningService;
-        private readonly IAssemblyVersioningService _assemblyVersioningService;
         private readonly ILogger<IncrementVersionWithCustomGitHintsHandler> _logger;
 
         /// <summary>
         /// Default Constructor
         /// </summary>
         /// <param name="mediator">An abstraction for accessing application behaviors.</param>
-        /// <param name="gitService">An abstraction to facilitate testing without using the git integration.</param>
-        /// <param name="gitVersioningService">An abstraction for retrieving version hint info from git commit messages.</param>
-        /// <param name="assemblyVersioningService">An abstraction for working with assembly versions.</param>
         /// <param name="logger">A generic interface for logging.</param>
         public IncrementVersionWithCustomGitHintsHandler(
             IMediator mediator,
-            IGitService gitService,
-            IGitVersioningService gitVersioningService,
-            IAssemblyVersioningService assemblyVersioningService,
             ILogger<IncrementVersionWithCustomGitHintsHandler> logger)
         {
             _mediator = mediator;
-            _gitService = gitService;
-            _gitVersioningService = gitVersioningService;
-            _assemblyVersioningService = assemblyVersioningService;
             _logger = logger;
         }
 
@@ -94,6 +79,7 @@ namespace Application.GitVersioning.Handlers
             IEnumerable<string> patchTypeHints, IEnumerable<string> patchScopeHints, IEnumerable<string> patchSubjectHints)
         {
             IEnumerable<GitCommitVersionInfo> CommitsList = gitCommitVersionInfos;
+            skipScopeHints.Append("[skip hint]");
 
             if (caseInsensitiveHints)
             {

--- a/src/Application/GitVersioning/Handlers/IncrementVersionWithCustomGitHintsHandler.cs
+++ b/src/Application/GitVersioning/Handlers/IncrementVersionWithCustomGitHintsHandler.cs
@@ -1,0 +1,140 @@
+﻿using Application.AssemblyVersioning.Commands;
+using Application.GitVersioning.Commands;
+using Application.GitVersioning.Queries;
+using Application.Interfaces;
+using Domain.Entities;
+using Domain.Enumerations;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Semver;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Application.GitVersioning.Handlers
+{
+    /// <summary>
+    /// The <see cref="IRequestHandler{TRequest,TResponse}"/> responsible for incrementing the version with git integration based on git commit messages, with custom hints.
+    /// </summary>
+    public class IncrementVersionWithCustomGitHintsHandler : IRequestHandler<IncrementVersionWithCustomGitHintsCommand, Unit>
+    {
+        private readonly IMediator _mediator;
+        private readonly IGitService _gitService;
+        private readonly IGitVersioningService _gitVersioningService;
+        private readonly IAssemblyVersioningService _assemblyVersioningService;
+        private readonly ILogger<IncrementVersionWithCustomGitHintsHandler> _logger;
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        /// <param name="mediator">An abstraction for accessing application behaviors.</param>
+        /// <param name="gitService">An abstraction to facilitate testing without using the git integration.</param>
+        /// <param name="gitVersioningService">An abstraction for retrieving version hint info from git commit messages.</param>
+        /// <param name="assemblyVersioningService">An abstraction for working with assembly versions.</param>
+        /// <param name="logger">A generic interface for logging.</param>
+        public IncrementVersionWithCustomGitHintsHandler(
+            IMediator mediator,
+            IGitService gitService,
+            IGitVersioningService gitVersioningService,
+            IAssemblyVersioningService assemblyVersioningService,
+            ILogger<IncrementVersionWithCustomGitHintsHandler> logger)
+        {
+            _mediator = mediator;
+            _gitService = gitService;
+            _gitVersioningService = gitVersioningService;
+            _assemblyVersioningService = assemblyVersioningService;
+            _logger = logger;
+        }
+
+        /// <summary>Handles the request to increment the version with git integration.</summary>
+        /// <param name="request">The <see cref="IRequest{TResponse}"/> object responsible for incrementing the version with git integration.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        public async Task<Unit> Handle(IncrementVersionWithCustomGitHintsCommand request, CancellationToken cancellationToken)
+        {
+            var query = new GetCommitVersionInfosQuery { GitDirectory = request.GitDirectory, RemoteTarget = request.RemoteTarget, TipBranchName = request.BranchName };
+            IEnumerable<GitCommitVersionInfo> versionInfos = await _mediator.Send(query, cancellationToken);
+
+            VersionIncrement increment = this.DeterminePriorityIncrement(versionInfos, request.CaseInsensitiveHints,
+                request.SkipTypeHints, request.SkipScopeHints, request.SkipSubjectHints,
+                request.MajorTypeHints, request.MajorScopeHints, request.MajorSubjectHints,
+                request.MinorTypeHints, request.MinorScopeHints, request.MinorSubjectHints,
+                request.PatchTypeHints, request.PatchScopeHints, request.PatchSubjectHints);
+            _logger.LogInformation($"Increment '{increment}' was determined from the commits.");
+
+            var command = new IncrementVersionWithGitCommand { GitDirectory = request.GitDirectory, TargetDirectory = request.TargetDirectory, 
+                SearchOption = request.SearchOption, CommitAuthorEmail = request.CommitAuthorEmail, RemoteTarget = request.RemoteTarget, 
+                BranchName = request.BranchName, TagPrefix = request.TagPrefix, TagSuffix = request.TagSuffix, 
+                ExitBeta = (request.ExitBeta ?? versionInfos.Any(x=>x.ExitBeta)), VersionIncrement = increment};
+            return await _mediator.Send(command, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns the prioritized <see cref="VersionIncrement"/> from a collection of <see cref="GitCommitVersionInfo"/>s.
+        /// </summary>
+        /// <param name="gitCommitVersionInfos">A collection of <see cref="GitCommitVersionInfo"/>s.</param>
+        /// <param name="caseInsensitiveHints">Enable case-insensitive comparaison</param>
+        /// <param name="skipTypeHints">A collection of commit's types how will create a none increment</param>
+        /// <param name="skipScopeHints">A collection of commit's scopes how will create a none increment</param>
+        /// <param name="skipSubjectHints">A collection of commit's subjects hints how will create a none increment</param>
+        /// <param name="majorTypeHints">A collection of commit's types how will create a major increment</param>
+        /// <param name="majorScopeHints">A collection of commit's scopes how will create a major increment</param>
+        /// <param name="majorSubjectHints">A collection of commit's subjects hints how will create a major increment</param>
+        /// <param name="minorTypeHints">A collection of commit's types how will create a minor increment</param>
+        /// <param name="minorScopeHints">A collection of commit's scopes how will create a minor increment</param>
+        /// <param name="minorSubjectHints">A collection of commit's subjects hints how will create a minor increment</param>
+        /// <param name="patchTypeHints">A collection of commit's types how will create a patch increment</param>
+        /// <param name="patchScopeHints">A collection of commit's scopes how will create a patch increment</param>
+        /// <param name="patchSubjectHints">A collection of commit's subjects hints how will create a patch increment</param>
+        /// <returns></returns>
+        private VersionIncrement DeterminePriorityIncrement(IEnumerable<GitCommitVersionInfo> gitCommitVersionInfos, bool caseInsensitiveHints,
+            IEnumerable<string> skipTypeHints, IEnumerable<string> skipScopeHints, IEnumerable<string> skipSubjectHints,
+            IEnumerable<string> majorTypeHints, IEnumerable<string> majorScopeHints, IEnumerable<string> majorSubjectHints,
+            IEnumerable<string> minorTypeHints, IEnumerable<string> minorScopeHints, IEnumerable<string> minorSubjectHints,
+            IEnumerable<string> patchTypeHints, IEnumerable<string> patchScopeHints, IEnumerable<string> patchSubjectHints)
+        {
+            IEnumerable<GitCommitVersionInfo> CommitsList = gitCommitVersionInfos;
+
+            if (caseInsensitiveHints)
+            {
+                CommitsList = CommitsList.Select(c => new GitCommitVersionInfo(c.Type.ToLower(), c.Scope.ToLower(), c.Subject.ToLower()));
+                skipTypeHints = skipTypeHints.Select(h => h.ToLower());
+                skipScopeHints = skipScopeHints.Select(h => h.ToLower());
+                skipSubjectHints = skipSubjectHints.Select(h => h.ToLower());
+                majorTypeHints = majorTypeHints.Select(h => h.ToLower());
+                majorScopeHints = majorScopeHints.Select(h => h.ToLower());
+                majorSubjectHints = majorSubjectHints.Select(h => h.ToLower());
+                minorTypeHints = minorTypeHints.Select(h => h.ToLower());
+                minorScopeHints = minorScopeHints.Select(h => h.ToLower());
+                minorSubjectHints = minorSubjectHints.Select(h => h.ToLower());
+                patchTypeHints = patchTypeHints.Select(h => h.ToLower());
+                patchScopeHints = patchScopeHints.Select(h => h.ToLower());
+                patchSubjectHints = patchSubjectHints.Select(h => h.ToLower());
+            }
+
+            IEnumerable<GitCommitVersionInfo> SkipedCommits = CommitsList.Where(c => skipTypeHints.Any(th => th == c.Type) 
+                                                                            || skipScopeHints.Any(ch => ch == c.Scope) 
+                                                                            || skipSubjectHints.Any(uh => uh.Contains(c.Subject)));
+
+            CommitsList = CommitsList.Except(SkipedCommits);
+
+            bool isMajor = CommitsList.Any(c => majorTypeHints.Any(th => th == c.Type)
+                                            || majorScopeHints.Any(ch => ch == c.Scope)
+                                            || majorSubjectHints.Any(uh => uh.Contains(c.Subject)));
+            if (isMajor) return VersionIncrement.Major;
+
+            bool isMinor = CommitsList.Any(c => minorTypeHints.Any(th => th == c.Type)
+                                            || minorScopeHints.Any(ch => ch == c.Scope)
+                                            || minorSubjectHints.Any(uh => uh.Contains(c.Subject)));
+            if (isMinor) return VersionIncrement.Minor;
+
+            bool isPatch = CommitsList.Any(c => patchTypeHints.Any(th => th == c.Type)
+                                            || patchScopeHints.Any(ch => ch == c.Scope)
+                                            || patchSubjectHints.Any(uh => uh.Contains(c.Subject)));
+            if (isPatch) return VersionIncrement.Patch;
+
+            bool isNone = SkipedCommits.Any();
+            return isNone ? VersionIncrement.None : VersionIncrement.Unknown;
+        }
+    }
+}

--- a/src/Application/GitVersioning/Validators/IncrementVersionWithCustomGitHintsValidator.cs
+++ b/src/Application/GitVersioning/Validators/IncrementVersionWithCustomGitHintsValidator.cs
@@ -1,0 +1,26 @@
+﻿using Application.GitVersioning.Commands;
+using FluentValidation;
+using System.IO;
+
+namespace Application.GitVersioning.Validators
+{
+    /// <summary>
+    /// The validator responsible for enforcing business rules for the <see cref="IncrementVersionWithCustomGitHintsCommand"/>.
+    /// </summary>
+    public class IncrementVersionWithCustomGitHintsValidator : AbstractValidator<IncrementVersionWithCustomGitHintsCommand>
+    {
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public IncrementVersionWithCustomGitHintsValidator()
+        {
+            RuleFor(x => x.GitDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.");
+            RuleFor(x => x.GitDirectory).Must(x => Directory.Exists(Path.Join(x, ".git"))).WithMessage("Must be a valid .git directory.");
+            RuleFor(x => x.CommitAuthorEmail).NotNull().NotEmpty();
+            RuleFor(x => x.BranchName).NotNull().NotEmpty();
+
+            RuleFor(x => x.TargetDirectory).Must(Directory.Exists).WithMessage("Must be a valid directory.")
+                .When(x => !string.IsNullOrWhiteSpace(x.TargetDirectory));
+        }
+    }
+}

--- a/src/Presentation.Console/Commands/App.cs
+++ b/src/Presentation.Console/Commands/App.cs
@@ -6,7 +6,7 @@ namespace Presentation.Console.Commands
     /// The versioning commandline application.
     /// </summary>
     [Command("dotnet-version")]
-    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGit), typeof(IncrementVersionWithGitHints))]
+    [Subcommand(typeof(IncrementVersion), typeof(IncrementVersionWithGit), typeof(IncrementVersionWithGitHints), typeof(IncrementVersionWithCustomGitHints))]
     public class App
     {
         /// <summary>

--- a/src/Presentation.Console/Commands/IncrementVersionWithCustomGitHints.cs
+++ b/src/Presentation.Console/Commands/IncrementVersionWithCustomGitHints.cs
@@ -1,0 +1,203 @@
+using Application.GitVersioning.Commands;
+using McMaster.Extensions.CommandLineUtils;
+using MediatR;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Presentation.Console.Commands
+{
+    /// <summary>
+    /// Increment versions in csproj files with git integration based on git commit messages, with custom hint.
+    /// </summary>
+    [Command(Description = "Increment versions in csproj files with git integration based on git commit messages, with custom hint.")]
+    public class IncrementVersionWithCustomGitHints
+    {
+        private readonly IMediator _mediator;
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        /// <param name="mediator">An abstraction for accessing application behaviors.</param>
+#pragma warning disable 8618
+        public IncrementVersionWithCustomGitHints(IMediator mediator)
+#pragma warning restore 8618
+        {
+            _mediator = mediator;
+            RemoteTarget = "origin";
+            AuthorEmail = "tool@versioning.net";
+            ExitBeta = null;
+            TagPrefix = "v";
+            TagSuffix = string.Empty;
+            CaseInsensitiveHints = false;
+        }
+
+        /// <summary>
+        /// The directory containing the .git folder.
+        /// </summary>
+        [Option(Description = "The directory containing the .git folder.")]
+        [Required]
+        public string GitDirectory { get; set; }
+
+        /// <summary>
+        /// The directory to use for file versioning. Defaults to the GitDirectory if not provided.
+        /// </summary>
+        [Option(ShortName = "d", Description = "The directory to use for file versioning. Defaults to the GitDirectory if not provided.")]
+        public string TargetDirectory { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The search option to use with the <see cref="TargetDirectory"/>. Defaults to <see cref="SearchOption.AllDirectories"/>.
+        /// </summary>
+        [Option(Description = "The search option to use with the target directory. Defaults to AllDirectories.")]
+        [AllowedValues("AllDirectories", "TopDirectoryOnly", IgnoreCase = true)]
+        public SearchOption SearchOption { get; set; } = SearchOption.AllDirectories;
+
+        /// <summary>
+        /// The git remote target. Defaults to 'origin'.
+        /// </summary>
+        [Option(ShortName = "t", Description = "The git remote target. Defaults to 'origin'.")]
+        public string RemoteTarget { get; set; }
+
+        /// <summary>
+        /// The name of the branch to update.
+        /// </summary>
+        [Option(Description = "The name of the branch to update.")]
+        [Required]
+        public string BranchName { get; set; }
+
+        /// <summary>
+        /// The git commit author's email address.
+        /// </summary>
+        [Option(Description = "The git commit author's email address.")]
+        public string AuthorEmail { get; set; }
+
+        /// <summary>
+        /// Determines whether beta mode should be exited.
+        /// </summary>
+        [Option(Description = "Determines whether beta mode should be exited. This will set the version to 1.0.0 if the version was lower.")]
+        public bool? ExitBeta { get; set; }
+
+        /// <summary>
+        /// The prefix value to use for the version tag in git. Defaults to 'v'.
+        /// </summary>
+        [Option(ShortName = "tp", Description = "The prefix value to use for the version tag in git. Defaults to 'v'.")]
+        public string TagPrefix { get; set; }
+
+        /// <summary>
+        /// The suffix value to use for the version tag in git.
+        /// </summary>
+        [Option(ShortName = "ts", Description = "The suffix value to use for the version tag in git.")]
+        public string TagSuffix { get; set; }
+
+        /// <summary>
+        /// Determines whether git hints should be case-insensitive.
+        /// </summary>
+        [Option(ShortName = "ci", Description = "Determines whether git hints should be case-insensitive. Default to false")]
+        public bool CaseInsensitiveHints { get; set; }
+
+        /// <summary>
+        /// Determines commit's types how will not create a increment.
+        /// </summary>
+        [Option(ShortName = "hst", Description = "Determines commit's types how will not create a increment.")]
+        public string[] SkipTypeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's scopes how will not create a increment.
+        /// </summary>
+        [Option(ShortName = "hsc", Description = "Determines commit's scopes how will not create a increment.")]
+        public string[] SkipScopeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's subject's hints how will not create a increment.
+        /// </summary>
+        [Option(ShortName = "hsu", Description = "Determines commit's subject's hints how will not create a increment.")]
+        public string[] SkipSubjectHints { get; set; } = { "[skip hint]" };
+
+        /// <summary>
+        /// Determines commit's types how will create a major increment.
+        /// </summary>
+        [Option(ShortName = "hat", Description = "Determines commit's types how will create a major increment.")]
+        public string[] MajorTypeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's scopes how will create a major increment.
+        /// </summary>
+        [Option(ShortName = "hac", Description = "Determines commit's scopes how will create a major increment.")]
+        public string[] MajorScopeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's subject's hints how will create a major increment.
+        /// </summary>
+        [Option(ShortName = "hau", Description = "Determines commit's subject's hints how will create a major increment.")]
+        public string[] MajorSubjectHints { get; set; } = { "#breaking" };
+
+        /// <summary>
+        /// Determines commit's types how will create a minor increment.
+        /// </summary>
+        [Option(ShortName = "hit", Description = "Determines commit's types how will create a minor increment.")]
+        public string[] MinorTypeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's scopes how will create a minor increment.
+        /// </summary>
+        [Option(ShortName = "hic", Description = "Determines commit's scopes how will create a minor increment.")]
+        public string[] MinorScopeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's subject's hints how will create a minor increment.
+        /// </summary>
+        [Option(ShortName = "hiu", Description = "Determines commit's subject's hints how will create a minor increment.")]
+        public string[] MinorSubjectHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's types how will create a patch increment.
+        /// </summary>
+        [Option(ShortName = "hpt", Description = "Determines commit's types how will create a patch increment.")]
+        public string[] PatchTypeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's scopes how will create a patch increment.
+        /// </summary>
+        [Option(ShortName = "hpc", Description = "Determines commit's scopes how will create a patch increment.")]
+        public string[] PatchScopeHints { get; set; } = System.Array.Empty<string>();
+
+        /// <summary>
+        /// Determines commit's subject's hints how will create a patch increment.
+        /// </summary>
+        [Option(ShortName = "hpu", Description = "Determines commit's subject's hints how will create a patch increment.")]
+        public string[] PatchSubjectHints { get; set; } = System.Array.Empty<string>();
+
+        // ReSharper disable once UnusedMember.Local
+        private async Task OnExecuteAsync()
+        {
+            var command = new IncrementVersionWithCustomGitHintsCommand
+            {
+                GitDirectory = GitDirectory,
+                TargetDirectory = TargetDirectory,
+                SearchOption = SearchOption,
+                CommitAuthorEmail = AuthorEmail,
+                RemoteTarget = RemoteTarget,
+                BranchName = BranchName,
+                ExitBeta = ExitBeta,
+                TagPrefix = TagPrefix,
+                TagSuffix = TagSuffix,
+                CaseInsensitiveHints = CaseInsensitiveHints,
+                SkipTypeHints = new List<string>(SkipTypeHints),
+                SkipScopeHints = new List<string>(SkipScopeHints),
+                SkipSubjectHints = new List<string>(SkipSubjectHints),
+                MajorTypeHints = new List<string>(MajorTypeHints),
+                MajorScopeHints = new List<string>(MajorScopeHints),
+                MajorSubjectHints = new List<string>(MajorSubjectHints),
+                MinorTypeHints = new List<string>(MinorTypeHints),
+                MinorScopeHints = new List<string>(MinorScopeHints),
+                MinorSubjectHints = new List<string>(MinorSubjectHints),
+                PatchTypeHints = new List<string>(PatchTypeHints),
+                PatchScopeHints = new List<string>(PatchScopeHints),
+                PatchSubjectHints = new List<string>(PatchSubjectHints)
+            };
+            await _mediator.Send(command, CancellationToken.None);
+        }
+    }
+}

--- a/src/Presentation.Console/Commands/IncrementVersionWithCustomGitHints.cs
+++ b/src/Presentation.Console/Commands/IncrementVersionWithCustomGitHints.cs
@@ -113,7 +113,7 @@ namespace Presentation.Console.Commands
         /// Determines commit's subject's hints how will not create a increment.
         /// </summary>
         [Option(ShortName = "hsu", Description = "Determines commit's subject's hints how will not create a increment.")]
-        public string[] SkipSubjectHints { get; set; } = { "[skip hint]" };
+        public string[] SkipSubjectHints { get; set; } = System.Array.Empty<string>();
 
         /// <summary>
         /// Determines commit's types how will create a major increment.


### PR DESCRIPTION
**What this PR does:** 
This is the solution I was thinking about for #27

- Enable the possibility of custom commit type how will hint the versioning
- Enable the possibility of custom commit scope how will hint the versioning
- Enable the possibility to custom commit subject flag how will hint the versioning
- Enable the possibility to make hints case-insensitive

By default, only the `#breaking` flag is enabled (for the major subject hint).
The flag `[skip hint]` can not be disabled.

**Special notes for reviewers: **

- I don't make any test for this new command, because I'm not sure what should I test and what I shouldn't.
- I'm not sure the command line will work because I don't know how to make a command line argument how will take an array.
- Maybe also the shortname is not the best.
